### PR TITLE
Ability to define the order and list of date-pickers

### DIFF
--- a/src/picker/components/picker/picker.component.ts
+++ b/src/picker/components/picker/picker.component.ts
@@ -118,6 +118,12 @@ export class DateTimePickerComponent<TDate = any> implements OnInit, OnDestroy
     public set options(value: DateTimePickerOptions<DateTimePicker<TDate>>)
     {
         this._options = extend(true, this._options, value);
+
+        // without deep-copy for this attribute
+        if (value?.pickerPeriodsDefinition)
+        {
+            this._options.pickerPeriodsDefinition = value.pickerPeriodsDefinition
+        }
     }
 
     /**
@@ -178,6 +184,11 @@ export class DateTimePickerComponent<TDate = any> implements OnInit, OnDestroy
                 protected _changeDetector: ChangeDetectorRef)
     {
         this._options = extend(true, {}, defaultConfiguration, configuration);
+        // without deep-copy for this attribute
+        if (configuration?.pickerPeriodsDefinition)
+        {
+            this._options.pickerPeriodsDefinition = configuration.pickerPeriodsDefinition
+        }
     }
 
     //######################### public methods - implementation of OnInit #########################
@@ -281,7 +292,7 @@ export class DateTimePickerComponent<TDate = any> implements OnInit, OnDestroy
             return;
         }
 
-        //sets shared css 
+        //sets shared css
         this._activePicker.setCssClasses(this._options?.cssClasses?.pickerShared ?? {});
 
         if(this._options?.cssClasses?.pickerCustom && this._options?.cssClasses?.pickerCustom[this._activePickerName])

--- a/src/picker/components/picker/picker.component.ts
+++ b/src/picker/components/picker/picker.component.ts
@@ -198,14 +198,40 @@ export class DateTimePickerComponent<TDate = any> implements OnInit, OnDestroy
      */
     public ngOnInit()
     {
-        if(!this._options.pickerPeriodsDefinition![this._options.defaultPeriod!])
+        if (this._options.pickerPeriodsOrder)
+        {
+            if (Array.isArray(this._options.pickerPeriodsOrder))
+            {
+                this._pickerNames = this._options.pickerPeriodsOrder
+            }
+            else
+            {
+                this._pickerNames = this._options.pickerPeriodsOrder.split(',')
+                                    .map(x => x.trim())
+                                    .filter(x => x)
+            }
+        }
+        if (this._pickerNames && this._pickerNames.length > 0)
+        {
+            this._pickerNames.forEach(x => {
+                if(!this._options.pickerPeriodsDefinition![x!])
+                {
+                    throw new Error(`There is no period '${x}' in picker options`);
+                }
+            })
+        }
+        else
+        {
+            this._pickerNames = Object.keys(this._options.pickerPeriodsDefinition!);
+        }
+
+        if(this._pickerNames.findIndex(x => x == this._options.defaultPeriod) < 0)
         {
             throw new Error(`There is no period '${this._options.defaultPeriod}' in picker options`);
         }
 
         this.activePickerComponent = this._options.pickerPeriodsDefinition![this._options.defaultPeriod!];
         this._activePickerName = this._options.defaultPeriod!;
-        this._pickerNames = Object.keys(this._options.pickerPeriodsDefinition!);
         this.activePickerIndex = this._pickerNames.indexOf(this._activePickerName);
     }
 

--- a/src/picker/misc/datetimePicker.interface.ts
+++ b/src/picker/misc/datetimePicker.interface.ts
@@ -63,6 +63,11 @@ export interface DateTimePickerCssClasses
 export interface DateTimePickerOptions<TPicker = any>
 {
     /**
+     * Order of pickers, it's possible use less pickers as is defined in pickerPeriodsDefinition for example 'month,year'
+     */
+    pickerPeriodsOrder?: string[] | string
+
+    /**
      * Definition of types for each period type for picker
      */
     pickerPeriodsDefinition?: Dictionary<Type<TPicker>>;

--- a/src/selector/components/selector/selector.component.ts
+++ b/src/selector/components/selector/selector.component.ts
@@ -224,6 +224,11 @@ export class DateTimeSelectorComponent<TDate = any> implements OnInit, OnChanges
     public set options(value: DateTimeSelectorOptions<DateTimeSelector<TDate>>)
     {
         this._options = extend(true, this._options, value);
+        // without deep-copy for this attribute
+        if (value?.pickerPeriodsDefinition)
+        {
+            this._options.pickerPeriodsDefinition = value.pickerPeriodsDefinition
+        }
     }
 
     /**
@@ -327,6 +332,11 @@ export class DateTimeSelectorComponent<TDate = any> implements OnInit, OnChanges
     {
         this.format = formatProvider.date;
         this._options = extend(true, {}, defaultConfiguration, configuration);
+        // without deep-copy for this attribute
+        if (configuration?.pickerPeriodsDefinition)
+        {
+            this._options.pickerPeriodsDefinition = configuration.pickerPeriodsDefinition
+        }
     }
 
     //######################### public methods - implementation of OnInit #########################


### PR DESCRIPTION
Usage with directive for `YearMonth` selector 

```typescript
@Directive({
    selector: "date-time-selector[yearMonth]",
})
export class YearMonthDirective {

    constructor(private _select: DateTimeSelectorComponent) {
        this._select.options.pickerCloseOnValueSelect = true
        this._select.options.defaultPeriod = "month"
        this._select.options.pickerPeriodsOrder = "month,year"
        // this._select.options.pickerPeriodsOrder = ["month", "year"]
        this._select.format = "YYYY-MM"
    }

}
```